### PR TITLE
[Draft]: Added Exponential Retry Mechanism with Idempotency Headers

### DIFF
--- a/src/main/java/co/novu/common/base/NovuConfig.java
+++ b/src/main/java/co/novu/common/base/NovuConfig.java
@@ -11,6 +11,13 @@ public class NovuConfig {
         this.apiKey = apiKey;
     }
 
-    private String apiKey;
+	private String apiKey;
     private String baseUrl = "https://api.novu.co/v1/";
+    
+    private int maxRetries = 3;
+    private int minRetryDelayMillis = 500; // 500 milli seconds
+    private int maxRetryDelayMillis = 60000; // 60 seconds
+    private int initialRetryDelayMillis = 1000; // 1 second
+    private boolean enableRetry = true; // To enable/disable retry logic
+    private boolean enableIdempotencyKey = true; // To enable/disable idempotency key
 }

--- a/src/main/java/co/novu/common/rest/IdempotencyKeyInterceptor.java
+++ b/src/main/java/co/novu/common/rest/IdempotencyKeyInterceptor.java
@@ -1,0 +1,29 @@
+package co.novu.common.rest;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+
+public class IdempotencyKeyInterceptor implements Interceptor{
+
+	@Override
+	public Response intercept(Chain chain) throws IOException {
+		Request request = chain.request();
+        Response response = null;
+        
+        Request requestWithIdempotencyKey = request.newBuilder()
+        		.header("Idempotency-Key", generateIdempotencyKey())
+                .build();
+        response = chain.proceed(requestWithIdempotencyKey);
+        return response;
+	}
+	
+	private String generateIdempotencyKey() {
+        UUID uuid = UUID. randomUUID();
+        return uuid.toString();
+    }
+
+}

--- a/src/main/java/co/novu/common/rest/RetryInterceptor.java
+++ b/src/main/java/co/novu/common/rest/RetryInterceptor.java
@@ -1,0 +1,62 @@
+package co.novu.common.rest;
+
+import java.io.IOException;
+
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+
+public class RetryInterceptor implements Interceptor{
+	
+	private final int maxRetries;
+	private final int minRetryDelayMillis;
+	private final int maxRetryDelayMillis;
+    private final int initialRetryDelayMillis;
+       
+    public RetryInterceptor(int maxRetries, int minRetryDelayMillis, int maxRetryDelayMillis, int initialRetryDelayMillis) {
+        this.maxRetries = maxRetries;
+        this.minRetryDelayMillis = minRetryDelayMillis;
+        this.maxRetryDelayMillis = maxRetryDelayMillis;
+        this.initialRetryDelayMillis = initialRetryDelayMillis;
+    }
+
+	@Override
+	public Response intercept(Chain chain) throws IOException {
+		Request request = chain.request();
+        Response response = null;
+        IOException lastException = null;
+
+        for (int retry = 0; retry < maxRetries; retry++) {
+            try {
+                response = chain.proceed(request);
+                if (response.isSuccessful()) {
+                    return response; // Request was successful, no need to retry
+                }
+            } catch (IOException e) {
+                lastException = e;
+            }
+
+            try {
+            	int retryDelay;
+                if (retry == 0) {
+                    retryDelay = initialRetryDelayMillis;
+                } else {
+                    retryDelay = (int) (initialRetryDelayMillis * Math.pow(2, retry - 1));
+                }
+                retryDelay = Math.max(retryDelay, minRetryDelayMillis);
+                retryDelay = Math.min(retryDelay, maxRetryDelayMillis);
+                Thread.sleep(retryDelay);
+            } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+            }
+        }
+
+        // If all retries failed, throw the last exception
+        if (lastException != null) {
+            throw lastException;
+        }
+
+        return response;
+    }
+
+}


### PR DESCRIPTION
Related to #79 

Hi @Cliftonz,
Please review this Draft PR as I am progressing on it.
- As we were already using `okhttp3` library, I have used the same library to implement the requirement as `Interceptors`.
- As per the original requirement, I have added configuration options for enabling/disabling the Exponential Retry mechanism and Idempotency Key provisioning.
- Provision to add Idempotency-Key in Header.
- Configuration for Exponential Retry Mechanism as per novu-go SDK

Will keep you updated as I progress on this issue.